### PR TITLE
Prepare for bug 1651538

### DIFF
--- a/activedata_etl/imports/task.py
+++ b/activedata_etl/imports/task.py
@@ -92,6 +92,7 @@ NULL_TASKS = (
     "build-ui-",
     "checksums-signing-",
     "Cron task for ",
+    "docker-image-",
     "partials-signing-",
     "partials-",
     "repackage-l10n-",


### PR DESCRIPTION
Bug 1651538 is going to relabel docker images from `build-docker-image-*` to `docker-image-*`.